### PR TITLE
Utilize lodash for deep merging of transformed object properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 /* jshint node: true, asi: true, laxcomma: true, esversion: 6 */
 'use strict'
 
+const _ = require('lodash')
+
 class AutoBot {
     // TODO no dupe keys flag/warning
     constructor () {
@@ -28,7 +30,7 @@ class AutoBot {
                 // thus the new object is composed of the correct key names with
                 // data extracted from old key names
                 let res = transform(entity, key, entity[key])
-                Object.assign(newEntity, res)
+                _.merge(newEntity, res)
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   "license": "MIT",
   "engines": {
     "node": "^6.9.1"
+  },
+  "dependencies": {
+    "lodash": "^4.17.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,11 +7,17 @@
     "url": "https://github.com/enlore/eims-autobot"
   },
   "main": "index.js",
+  "scripts": {
+    "test": "mocha test"
+  },
   "license": "MIT",
   "engines": {
     "node": "^6.9.1"
   },
   "dependencies": {
     "lodash": "^4.17.4"
+  },
+  "devDependencies": {
+    "mocha": "^3.5.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,103 @@
+'use strict'
+
+let AutoBot = require('../index.js')
+let assert = require('assert')
+
+describe('AutoBot', function() {
+    describe('transform() - no cross-key transforms', function() {
+        it('should make a 1-to-1 transform', function() {
+
+            let optimus = new AutoBot()
+            optimus.registerTransform('Windshield', toChest)
+            optimus.registerTransform('FrontWheels', toArms)
+            optimus.registerTransform('BackWheels', toLegs)
+            
+            function toChest(truck, key, windshield) {
+                return {
+                    Chest: windshield
+                }
+            }
+            
+            function toArms(truck, key, frontWheels) {
+                return {
+                    Arms: frontWheels
+                }
+            }
+            
+            function toLegs(truck, key, backWheels) {
+                return {
+                    Legs: {
+                        Left: backWheels / 2,
+                        Right: backWheels / 2
+                    }
+                }
+            }
+            
+            let truckForm = {
+                Windshield: "black tinted",
+                FrontWheels: 2,
+                BackWheels: 8
+            }
+
+            let targetObject = {
+                Chest: 'black tinted',
+                Arms: 2,
+                Legs: {
+                    Left: 4,
+                    Right: 4
+                }
+            }
+
+            assert.deepEqual(targetObject, optimus.transform(truckForm))
+        })
+    })
+
+    describe('transform() - with cross-key transforms', function() {
+        it('should be able to save nested values from transforms into the same property', function() {
+
+            let bumblebee = new AutoBot()
+            bumblebee.registerTransform('Radio', toVoiceBox) 
+            bumblebee.registerTransform('FrontWheels', toArms)
+            bumblebee.registerTransform('BackWheels', toLegs)
+
+            function toVoiceBox(car, key, radio) {
+                return {
+                    VoiceBox: radio
+                }
+            }
+
+            // The following two transforms save data nested within an 'Appendages' property
+            function toArms(car, key, frontWheels) {
+                return {
+                    Appendages: {
+                        Arms: frontWheels
+                    }
+                }
+            }
+
+            function toLegs(car, key, backWheels) {
+                return {
+                    Appendages: {
+                        Legs: backWheels
+                    }
+                }
+            }
+
+            let carForm = {
+                Radio: 'Bluetooth Touchscreen Car Radio',
+                FrontWheels: 2,
+                BackWheels: 2
+            }
+
+            let targetObject = {
+                VoiceBox: 'Bluetooth Touchscreen Car Radio',
+                Appendages: {
+                    Arms: 2,
+                    Legs: 2
+                }
+            }
+
+            assert.deepEqual(targetObject, bumblebee.transform(carForm))
+        })
+    })
+})


### PR DESCRIPTION
I used lodash's merge function instead of Object.assign to add newly transformed properties to the object being transformed. Prior to this, Object.assign would override any value in a property set by multiple transforms.

For example: if transforms A and B both set properties (C and D, respectively) within a property called E, one would expect the object to contain a property post-transform of E: {C, D}.
However, because Object.assign only makes shallow copies, the result would only be E: {C} or E: {D}, depending on if A or B was the last transform.

Using _.merge from lodash solves this problem.

I also included mocha as a dev dependency, and some sample Unit Tests to demonstrate 1-to-1 transforms, as well as nested property transforms (discussed above).